### PR TITLE
Fix for language overrides, paths & properties.

### DIFF
--- a/source/plugins/system/languagedomains/languagedomains.php
+++ b/source/plugins/system/languagedomains/languagedomains.php
@@ -45,7 +45,7 @@ class plgSystemLanguageDomains extends plgSystemLanguageFilter
 		$rt = parent::__construct($subject, $config);
 
         // Load the current language as detected from the URL
-		$currentLanguageTag = $application->input->get('language');
+		$currentLanguageTag = JFactory::getLanguage()->getTag();
 
 		// If this is the Site-application
 		if ($application->isSite() == true)
@@ -200,6 +200,7 @@ class plgSystemLanguageDomains extends plgSystemLanguageFilter
 		if (!empty($languageTag))
 		{
 			JRequest::setVar('language', $languageTag);
+			JFactory::getLanguage()->__construct($languageTag);
 			JFactory::getLanguage()->setLanguage($languageTag);
 
 			$component = JComponentHelper::getComponent('com_languages');


### PR DESCRIPTION
- missing additional languages overrides and fallback to default site language overrides;
- incorrect paths to *.ini files;
- incorrect JLanguage properties (fallback to default site language properties).
##### Fix 1

Without line 48 some paths look like this:

``` php
[joomla] => Array
    (
        ....
        [D:\XAMPP\htdocs\joomla/language/.ini] => 
    )

[plg_system_logout] => Array
    (
        ....
        [D:\XAMPP\htdocs\joomla/administrator/language/.plg_system_logout.ini] => 
   )
```

This is happening because `$application->input->get('language');` is empty or does not exist.
##### Fix 2

Without line 203 the current language is not registered "completly" let's say and the overrides for current language are missing + JLanguage properties (like upperLimitSearchWordCallback, ignoredSearchWordsCallback, etc) fallback to default site language ones.

Everything works now!
