### PR TITLE
Update languagedomains.xml

### DIFF
--- a/source/plugins/system/languagedomains/languagedomains.xml
+++ b/source/plugins/system/languagedomains/languagedomains.xml
@@ -2,12 +2,12 @@
 <extension version="2.5" type="plugin" group="system" method="upgrade">
     <name>PLG_SYSTEM_LANGUAGEDOMAINS</name>
     <author>Yireo</author>
-    <creationDate>September 2016</creationDate>
+    <creationDate>July 2017</creationDate>
     <copyright>Copyright 2016 Yireo.com. All rights reserved.</copyright>
     <license>http://www.gnu.org/copyleft/gpl.html GNU/GPL</license>
     <authorEmail>development@yireo.com</authorEmail>
     <authorUrl>http://www.yireo.com/</authorUrl>
-    <version>1.0.54</version>
+    <version>1.0.55</version>
     <description>PLG_SYSTEM_LANGUAGEDOMAINS_DESC</description>
 
     <files>


### PR DESCRIPTION
Update version languagedomains from 1.0.54 to 1.0.55
fix bug after update from joomla 3.7.2 to joomla 3.7.3 (change in languagedomains.php)
bug fixed: remove prefix in home page of main language for example: from  http://www.site.com/en to http://www.site.com/
